### PR TITLE
Update Requirements.txt to fix dependabot alerts #1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ tqdm~=4.64.1
 # tests
 pytest>=7.2.0
 pytest-cov>=2.8.1
-setuptools~=57.0.0
+setuptools>=65.5.1


### PR DESCRIPTION
Python Packaging Authority (PyPA)'s setuptools is a library designed to facilitate packaging Python projects. Setuptools version 65.5.0 and earlier could allow remote attackers to cause a denial of service by fetching malicious HTML from a PyPI package or custom PackageIndex page due to a vulnerable Regular Expression in package_index. This has been patched in version 65.5.1.